### PR TITLE
chore(fix): unnecessary vertical scrollbar for editor buttons

### DIFF
--- a/src/pug/index.pug
+++ b/src/pug/index.pug
@@ -48,7 +48,7 @@ block content
 
     .flex-wrapper
       mixin editor-btns
-        .editor-btns(class="overflow-x-hidden pt-24")&attributes(attributes)
+        .editor-btns(class="overflow-hidden pt-24")&attributes(attributes)
           .flex-1
           div.relative
             .flex.flex-wrap.gap-2.editor-btn-container


### PR DESCRIPTION
Very minor, but I spotted this extra vertical scrollbar on the editor buttons that is unnecessary and covers the real scrollbar.

This could also be solved by removing the `overflow-x-hidden` instead; I didn't see a situation in which that would actually be of use, but I very well could be missing something. Setting both x & y to hidden is equally effective, just might be an unnecessary class is all.

> How it appears in Firefox

![Extra scrollbar in Firefox](https://user-images.githubusercontent.com/33403762/161904456-a5c27d45-d063-4f50-90ff-9593d7555841.png)
