### PR TITLE
Disable autocorrect for search input

### DIFF
--- a/src/pug/index.pug
+++ b/src/pug/index.pug
@@ -25,7 +25,7 @@ block content
     .search-container
       .search
         i.icon search
-        input#search-input(type="text" autocomplete="off" placeholder="Type a package name...")
+        input#search-input(type="text" autocorrect="off" autocomplete="off" placeholder="Type a package name...")
         button.btn.clear.umami--click--search-clear-button
           i.icon clear
 


### PR DESCRIPTION
Autocorrect will try to correct package names to words on MacOS and mobile devices. This disables that behaviour as we don't want it here.