### PR TITLE
chore: minor getCDNOrigin refactor

### DIFF
--- a/src/ts/util/util-cdn.ts
+++ b/src/ts/util/util-cdn.ts
@@ -78,10 +78,7 @@ export const getCDNOrigin = (importStr: string, cdn = DEFAULT_CDN_HOST) => {
     else if (/^(github)\:/.test(importStr)) 
         cdn = `https://raw.githubusercontent.com`;
 
-    if (!cdn.endsWith("/"))
-        cdn += "/";
-
-    return cdn;
+    return !/\/$/.test(cdn) ? `${cdn}/` : cdn;
 }
 
 /**

--- a/src/ts/util/util-cdn.ts
+++ b/src/ts/util/util-cdn.ts
@@ -78,7 +78,10 @@ export const getCDNOrigin = (importStr: string, cdn = DEFAULT_CDN_HOST) => {
     else if (/^(github)\:/.test(importStr)) 
         cdn = `https://raw.githubusercontent.com`;
 
-    return /\/$/.test(cdn) ? cdn : `${cdn}/`;
+    if (!cdn.endsWith("/"))
+        cdn += "/";
+
+    return cdn;
 }
 
 /**


### PR DESCRIPTION
easier to understand than
```
/\/$/.test(cdn) ? cdn : `${cdn}/`
```